### PR TITLE
gh-98 Enable AccumuloStore Import step to be run in two parts

### DIFF
--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/AddElementsFromHdfsHandler.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/AddElementsFromHdfsHandler.java
@@ -16,16 +16,15 @@
 
 package gaffer.accumulostore.operation.hdfs.handler;
 
-import org.apache.hadoop.util.ToolRunner;
-
 import gaffer.accumulostore.AccumuloStore;
-import gaffer.accumulostore.operation.hdfs.handler.tool.ImportElementsToAccumulo;
 import gaffer.accumulostore.operation.hdfs.handler.tool.FetchElementsFromHdfs;
+import gaffer.accumulostore.operation.hdfs.handler.tool.ImportElementsToAccumulo;
+import gaffer.accumulostore.utils.AccumuloStoreConstants;
 import gaffer.operation.OperationException;
 import gaffer.operation.simple.hdfs.AddElementsFromHdfs;
 import gaffer.store.Store;
-import gaffer.store.StoreException;
 import gaffer.store.operation.handler.OperationHandler;
+import org.apache.hadoop.util.ToolRunner;
 
 public class AddElementsFromHdfsHandler implements OperationHandler<AddElementsFromHdfs, Void> {
     @Override
@@ -36,7 +35,10 @@ public class AddElementsFromHdfsHandler implements OperationHandler<AddElementsF
 
     public void doOperation(final AddElementsFromHdfs operation, final AccumuloStore store) throws OperationException {
         fetchElements(operation, store);
-        importElements(operation, store);
+        String skipImport = operation.getOption(AccumuloStoreConstants.ADD_ELEMENTS_FROM_HDFS_SKIP_IMPORT);
+        if (null == skipImport || !skipImport.equalsIgnoreCase("TRUE"))  {
+            importElements(operation, store);
+        }
     }
 
     private void fetchElements(final AddElementsFromHdfs operation, final AccumuloStore store)
@@ -58,13 +60,8 @@ public class AddElementsFromHdfsHandler implements OperationHandler<AddElementsF
     private void importElements(final AddElementsFromHdfs operation, final AccumuloStore store)
             throws OperationException {
         final ImportElementsToAccumulo importTool;
-        try {
-            importTool = new ImportElementsToAccumulo(operation, store);
-        } catch (final StoreException e) {
-            throw new OperationException("Failed to import elements into Accumulo.", e);
-        }
-
         final int response;
+        importTool = new ImportElementsToAccumulo(operation.getOutputPath(), operation.getFailurePath(), store);
         try {
             response = ToolRunner.run(importTool, new String[0]);
         } catch (final Exception e) {

--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/ImportAccumuloKeyValueFilesHandler.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/ImportAccumuloKeyValueFilesHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gaffer.accumulostore.operation.hdfs.handler;
+
+import gaffer.accumulostore.AccumuloStore;
+import gaffer.accumulostore.operation.hdfs.handler.tool.ImportElementsToAccumulo;
+import gaffer.accumulostore.operation.hdfs.impl.ImportAccumuloKeyValueFiles;
+import gaffer.operation.OperationException;
+import gaffer.store.Store;
+import gaffer.store.operation.handler.OperationHandler;
+import org.apache.hadoop.util.ToolRunner;
+
+public class ImportAccumuloKeyValueFilesHandler implements OperationHandler<ImportAccumuloKeyValueFiles, Void> {
+    @Override
+    public Void doOperation(final ImportAccumuloKeyValueFiles operation, final Store store) throws OperationException {
+        doOperation(operation, (AccumuloStore) store);
+        return null;
+    }
+
+    public void doOperation(final ImportAccumuloKeyValueFiles operation, final AccumuloStore store) throws OperationException {
+        splitTable(operation, store);
+    }
+
+    private void splitTable(final ImportAccumuloKeyValueFiles operation, final AccumuloStore store) throws OperationException {
+        final ImportElementsToAccumulo importTool = new ImportElementsToAccumulo(operation.getInputPath(), operation.getFailurePath(), store);
+        try {
+            ToolRunner.run(importTool, new String[0]);
+        } catch (final Exception e) {
+            throw new OperationException(e.getMessage(), e);
+        }
+    }
+}

--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/tool/ImportElementsToAccumulo.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/tool/ImportElementsToAccumulo.java
@@ -15,53 +15,45 @@
  */
 package gaffer.accumulostore.operation.hdfs.handler.tool;
 
-import org.apache.accumulo.core.client.Connector;
+import gaffer.accumulostore.AccumuloStore;
+import gaffer.accumulostore.utils.IngestUtils;
+import gaffer.accumulostore.utils.TableUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsAction;
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Tool;
-
-import gaffer.accumulostore.AccumuloStore;
-import gaffer.accumulostore.utils.IngestUtils;
-import gaffer.operation.simple.hdfs.AddElementsFromHdfs;
-import gaffer.store.StoreException;
 
 public class ImportElementsToAccumulo extends Configured implements Tool {
     public static final int SUCCESS_RESPONSE = 0;
 
-    private final AddElementsFromHdfs operation;
-    private final Connector connector;
-    private final String table;
+    private final Path inputPath;
+    private final Path failurePath;
+    private final AccumuloStore store;
 
-    public ImportElementsToAccumulo(final AddElementsFromHdfs operation, final AccumuloStore store)
-            throws StoreException {
-        this.operation = operation;
-        this.connector = store.getConnection();
-        this.table = store.getProperties().getTable();
+    public ImportElementsToAccumulo(final Path inputPath, final Path failurePath, final AccumuloStore store) {
+        this.inputPath = inputPath;
+        this.failurePath = failurePath;
+        this.store = store;
     }
 
     @Override
     public int run(final String[] strings) throws Exception {
+        TableUtils.ensureTableExists(store);
+
         // Hadoop configuration
         final Configuration conf = getConf();
         final FileSystem fs = FileSystem.get(conf);
 
-        // Make the failure directory
-        fs.mkdirs(operation.getFailurePath());
-        fs.setPermission(operation.getFailurePath(), new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-
         // Remove the _SUCCESS file to prevent warning in accumulo
-        fs.delete(new Path(operation.getOutputPath().toString() + "/_SUCCESS"), false);
+        fs.delete(new Path(inputPath.toString() + "/_SUCCESS"), false);
 
         // Set all permissions
-        IngestUtils.setDirectoryPermsForAccumulo(fs, operation.getOutputPath());
+        IngestUtils.setDirectoryPermsForAccumulo(fs, failurePath);
 
         // Import the files
-        connector.tableOperations().importDirectory(table, operation.getOutputPath().toString(),
-                operation.getFailurePath().toString(), false);
+        store.getConnection().tableOperations().importDirectory(store.getProperties().getTable(), inputPath.toString(),
+                failurePath.toString(), false);
 
         return SUCCESS_RESPONSE;
     }

--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/impl/ImportAccumuloKeyValueFiles.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/impl/ImportAccumuloKeyValueFiles.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gaffer.accumulostore.operation.hdfs.impl;
+
+import gaffer.operation.AbstractOperation;
+import gaffer.operation.VoidOutput;
+import org.apache.hadoop.fs.Path;
+
+public class ImportAccumuloKeyValueFiles extends AbstractOperation<Path, Void> implements VoidOutput<Path> {
+
+    private Path failurePath;
+    private Path inputPath;
+
+    public ImportAccumuloKeyValueFiles() {
+
+    }
+
+    public Path getInputPath() {
+        return inputPath;
+    }
+
+    public void setInputPath(final Path inputPath) {
+        this.inputPath = inputPath;
+    }
+
+    public Path getFailurePath() {
+        return failurePath;
+    }
+
+    public void setFailurePath(final Path failurePath) {
+        this.failurePath = failurePath;
+    }
+
+    public static class Builder extends AbstractOperation.Builder<ImportAccumuloKeyValueFiles, Path, Void> {
+        public Builder() {
+            super(new ImportAccumuloKeyValueFiles());
+        }
+
+        public Builder inputPath(final Path inputPath) {
+            op.setInputPath(inputPath);
+            return this;
+        }
+
+        @Override
+        public Builder option(final String name, final String value) {
+            super.option(name, value);
+            return this;
+        }
+
+        public Builder failurePath(final Path failurePath) {
+            op.setFailurePath(failurePath);
+            return this;
+        }
+    }
+}

--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/impl/SampleDataForSplitPoints.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/impl/SampleDataForSplitPoints.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.Path;
  * The <code>SampleDataForSplitPoints</code> operation is for creating a splits file, either for use in a {@link gaffer.accumulostore.operation.hdfs.impl.SplitTable} operation or an
  * {@link gaffer.operation.simple.hdfs.AddElementsFromHdfs} operation.
  *
- * This operation requires an input, output and failure path as well as a path to a file to use as the resulitngSplitsFile.
+ * This operation requires an input and output path as well as a path to a file to use as the resulitngSplitsFile.
  * It order to be generic and deal with any type of input file you also need to provide a
  * {@link MapperGenerator} class name and a
  * {@link gaffer.operation.simple.hdfs.handler.jobfactory.JobInitialiser}.

--- a/accumulo-store/src/main/java/gaffer/accumulostore/utils/AccumuloStoreConstants.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/utils/AccumuloStoreConstants.java
@@ -66,6 +66,7 @@ public final class AccumuloStoreConstants {
     // Operations options
     public static final String OPERATION_HDFS_USE_ACCUMULO_PARTITIONER = "accumulostore.operation.hdfs.use_accumulo_partitioner";
     public static final String OPERATION_HDFS_SPLITS_FILE = "accumulostore.operation.hdfs.user_provided_splits_file";
+    public static final String ADD_ELEMENTS_FROM_HDFS_SKIP_IMPORT = "accumulostore.operation.hdfs.skip_import";
     public static final String OPERATION_AUTHORISATIONS = "accumulostore.operation.authorisations";
     public static final String OPERATION_RETURN_MATCHED_SEEDS_AS_EDGE_SOURCE = "accumulostore.operation.return_matched_id_as_edge_source";
 

--- a/simple-operation-library/src/main/java/gaffer/operation/simple/hdfs/AddElementsFromHdfs.java
+++ b/simple-operation-library/src/main/java/gaffer/operation/simple/hdfs/AddElementsFromHdfs.java
@@ -18,6 +18,7 @@ package gaffer.operation.simple.hdfs;
 import gaffer.operation.VoidInput;
 import gaffer.operation.VoidOutput;
 import gaffer.operation.simple.hdfs.handler.mapper.MapperGenerator;
+import org.apache.hadoop.fs.Path;
 
 
 /**
@@ -35,6 +36,7 @@ import gaffer.operation.simple.hdfs.handler.mapper.MapperGenerator;
  */
 public class AddElementsFromHdfs extends MapReduceOperation<Void, Void> implements VoidInput<Void>, VoidOutput<Void> {
 
+    private Path failurePath;
     private boolean validate = true;
 
     /**
@@ -44,6 +46,13 @@ public class AddElementsFromHdfs extends MapReduceOperation<Void, Void> implemen
      */
     private String mapperGeneratorClassName;
 
+    public Path getFailurePath() {
+        return failurePath;
+    }
+
+    public void setFailurePath(final Path failurePath) {
+        this.failurePath = failurePath;
+    }
 
     public boolean isValidate() {
         return validate;
@@ -77,6 +86,11 @@ public class AddElementsFromHdfs extends MapReduceOperation<Void, Void> implemen
 
         public Builder mapperGenerator(final Class<? extends MapperGenerator> mapperGeneratorClass) {
             op.setMapperGeneratorClassName(mapperGeneratorClass);
+            return this;
+        }
+
+        public Builder failurePath(final Path failurePath) {
+            op.setFailurePath(failurePath);
             return this;
         }
 

--- a/simple-operation-library/src/main/java/gaffer/operation/simple/hdfs/MapReduceOperation.java
+++ b/simple-operation-library/src/main/java/gaffer/operation/simple/hdfs/MapReduceOperation.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.mapreduce.Partitioner;
 public abstract class MapReduceOperation<INPUT, OUTPUT> extends AbstractOperation<INPUT, OUTPUT> {
     private Path inputPath;
     private Path outputPath;
-    private Path failurePath;
     private Integer numReduceTasks = null;
     private Integer numMapTasks = null;
 
@@ -64,14 +63,6 @@ public abstract class MapReduceOperation<INPUT, OUTPUT> extends AbstractOperatio
 
     public void setOutputPath(final Path outputPath) {
         this.outputPath = outputPath;
-    }
-
-    public Path getFailurePath() {
-        return failurePath;
-    }
-
-    public void setFailurePath(final Path failurePath) {
-        this.failurePath = failurePath;
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_OBJECT, property = "class")
@@ -120,11 +111,6 @@ public abstract class MapReduceOperation<INPUT, OUTPUT> extends AbstractOperatio
 
         public Builder outputPath(final Path outputPath) {
             op.setOutputPath(outputPath);
-            return this;
-        }
-
-        public Builder failurePath(final Path failurePath) {
-            op.setFailurePath(failurePath);
             return this;
         }
 


### PR DESCRIPTION
Added Option & AccumuloStoreConstant to skip import step on AddElementsFromHdfs for the accumulo-store
Added Operation to do the import of keys/values to Accumulo from a directory.
Moved failureDirectory path variable from MapReduceOperation to AddElementsFromHdfs & ImportKeyValueFiles.