### PR TITLE
gh-310 Refactor SampleDataForSplitPoints operation

### DIFF
--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/job/SampleDataForSplitPointsJobFactory.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/handler/job/SampleDataForSplitPointsJobFactory.java
@@ -78,10 +78,7 @@ public class SampleDataForSplitPointsJobFactory {
         if (null != numTasks) {
             jobConf.setNumMapTasks(numTasks);
         }
-        numTasks = operation.getNumReduceTasks();
-        if (null != numTasks) {
-            jobConf.setNumReduceTasks(numTasks);
-        }
+        jobConf.setNumReduceTasks(1);
     }
 
     protected void setupJob(final Job job, final SampleDataForSplitPoints operation, final Store store) throws IOException {

--- a/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/impl/SampleDataForSplitPoints.java
+++ b/accumulo-store/src/main/java/gaffer/accumulostore/operation/hdfs/impl/SampleDataForSplitPoints.java
@@ -52,6 +52,7 @@ public class SampleDataForSplitPoints extends MapReduceOperation<Void, String> i
     private String mapperGeneratorClassName;
 
     public SampleDataForSplitPoints() {
+        super.setNumReduceTasks(1);
     }
 
     public boolean isValidate() {
@@ -89,6 +90,16 @@ public class SampleDataForSplitPoints extends MapReduceOperation<Void, String> i
 
     public void setProportionToSample(final float proportionToSample) {
         this.proportionToSample = proportionToSample;
+    }
+
+    @Override
+    public void setNumReduceTasks(final Integer numReduceTasks) {
+        throw new IllegalArgumentException(getClass().getSimpleName() + " requires the number of reducers to be 1");
+    }
+
+    @Override
+    public void setPartitioner(final Class<? extends Partitioner> partitioner) {
+        throw new IllegalArgumentException(getClass().getSimpleName() + " is not able to set its own partitioner");
     }
 
     public static class Builder extends MapReduceOperation.Builder<SampleDataForSplitPoints, Void, String> {
@@ -148,18 +159,10 @@ public class SampleDataForSplitPoints extends MapReduceOperation<Void, String> i
         }
 
         @Override
-        public Builder reducers(final Integer numReduceTasks) {
-            return (Builder) super.reducers(numReduceTasks);
-        }
-
-        @Override
         public Builder mappers(final Integer numMapTasks) {
             return (Builder) super.mappers(numMapTasks);
         }
 
-        @Override
-        public Builder partioner(final Class<? extends Partitioner> partitioner) {
-            return (Builder) super.partioner(partitioner);
-        }
     }
+
 }

--- a/accumulo-store/src/test/java/gaffer/accumulostore/operation/hdfs/impl/SampleDataForSplitPointsTest.java
+++ b/accumulo-store/src/test/java/gaffer/accumulostore/operation/hdfs/impl/SampleDataForSplitPointsTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SampleDataForSplitPointsTest implements OperationTest {
     private static final JSONSerialiser serialiser = new JSONSerialiser();
@@ -28,7 +29,6 @@ public class SampleDataForSplitPointsTest implements OperationTest {
         op.setValidate(true);
         op.setProportionToSample(0.1f);
         op.setResultingSplitsFilePath(resultPath);
-        op.setNumReduceTasks(10);
         op.setNumMapTasks(5);
 
         // When
@@ -43,20 +43,30 @@ public class SampleDataForSplitPointsTest implements OperationTest {
         assertTrue(deserialisedOp.isValidate());
         assertEquals(0.1f, deserialisedOp.getProportionToSample(), 1);
         assertEquals(new Integer(5), deserialisedOp.getNumMapTasks());
-        assertEquals(new Integer(10), deserialisedOp.getNumReduceTasks());
+        assertEquals(new Integer(1), deserialisedOp.getNumReduceTasks());
 
     }
 
     @Test
     @Override
     public void builderShouldCreatePopulatedOperation() {
-        final SampleDataForSplitPoints sampleDataForSplitPoints = new SampleDataForSplitPoints.Builder().addInputPath(INPUT_DIRECTORY).option(TEST_OPTION_KEY, "true").reducers(10).proportionToSample(0.1f).validate(true).mappers(5).resultingSplitsFilePath("/test").build();
+        final SampleDataForSplitPoints sampleDataForSplitPoints = new SampleDataForSplitPoints.Builder().addInputPath(INPUT_DIRECTORY).option(TEST_OPTION_KEY, "true").proportionToSample(0.1f).validate(true).mappers(5).resultingSplitsFilePath("/test").build();
         assertEquals(INPUT_DIRECTORY, sampleDataForSplitPoints.getInputPaths().get(0));
         assertEquals("true", sampleDataForSplitPoints.getOption(TEST_OPTION_KEY));
         assertEquals("/test", sampleDataForSplitPoints.getResultingSplitsFilePath());
         assertTrue(sampleDataForSplitPoints.isValidate());
         assertEquals(0.1f, sampleDataForSplitPoints.getProportionToSample(), 1);
         assertEquals(new Integer(5), sampleDataForSplitPoints.getNumMapTasks());
-        assertEquals(new Integer(10), sampleDataForSplitPoints.getNumReduceTasks());
+    }
+
+    @Test
+    public void expectIllegalArgumentExceptionWhenTryingToSetReducers() {
+        final SampleDataForSplitPoints op = new SampleDataForSplitPoints();
+        try {
+            op.setNumReduceTasks(10);
+        } catch(IllegalArgumentException e) {
+            return;
+        }
+        fail();
     }
 }


### PR DESCRIPTION
Remove the ability to set the number of reducers and the partitioner from the Operation Builder and if set on the operation class it will result in an IllegalArgumentException
The Job Factory for this operation will now also always set the reducers to 1, as required for the operation to function correctly.