### PR TITLE
gh-397 - tidied up web.xml for example rest api

### DIFF
--- a/example-rest/src/main/webapp/WEB-INF/web.xml
+++ b/example-rest/src/main/webapp/WEB-INF/web.xml
@@ -3,16 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          version="3.0">
-    
-  <display-name>Gaffer REST example</display-name>
 
-    <servlet>
-        <servlet-name>Resteasy</servlet-name>
-        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-        <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
-            <param-value>example.rest.application.ApplicationConfig</param-value>
-        </init-param>
-    </servlet>
+    <display-name>Gaffer REST example</display-name>
 
 </web-app>


### PR DESCRIPTION
This sometimes caused conflicts when using the embedded jetty server. Due to this the python example sometimes didn't work.